### PR TITLE
convert ckeditor5-link to work for resource links

### DIFF
--- a/packages/ckeditor5-link/package.json
+++ b/packages/ckeditor5-link/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "@ckeditor/ckeditor5-link",
-  "version": "29.2.0",
-  "description": "Link feature for CKEditor 5.",
+  "name": "@mitodl/ckeditor5-resource-link",
+  "version": "29.2.0-beta.4",
+  "description": "MITODL fork of CKEditor 5 link feature.",
+  "public": true,
   "keywords": [
     "ckeditor",
     "ckeditor5",
@@ -44,11 +45,11 @@
   },
   "author": "CKSource (http://cksource.com/)",
   "license": "GPL-2.0-or-later",
-  "homepage": "https://ckeditor.com/ckeditor-5",
-  "bugs": "https://github.com/ckeditor/ckeditor5/issues",
+  "homepage": "https://github.com/mitodl/ckeditor5/",
+  "bugs": "https://github.com/mitodl/ckeditor5/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ckeditor/ckeditor5.git",
+    "url": "https://github.com/mitodl/ckeditor5.git",
     "directory": "packages/ckeditor5-link"
   },
   "files": [

--- a/packages/ckeditor5-link/src/autolink.js
+++ b/packages/ckeditor5-link/src/autolink.js
@@ -80,7 +80,7 @@ export default class AutoLink extends Plugin {
 	 * @inheritDoc
 	 */
 	static get pluginName() {
-		return 'AutoLink';
+		return 'ResourceAutoLink';
 	}
 
 	/**

--- a/packages/ckeditor5-link/src/constants.js
+++ b/packages/ckeditor5-link/src/constants.js
@@ -1,0 +1,9 @@
+export const RESOURCE_LINK = 'resourceLink'
+
+export const RESOURCE_LINK_UI = 'resourceLinkUI'
+
+export const RESOURCE_LINK_COMMAND = 'insertResourceLink'
+
+export const RESOURCE_UNLINK_COMMAND = 'removeResourceLink'
+
+export const RESOURCE_LINK_CKEDITOR_CLASS = "resource-link"

--- a/packages/ckeditor5-link/src/link.js
+++ b/packages/ckeditor5-link/src/link.js
@@ -9,8 +9,8 @@
 
 import { Plugin } from 'ckeditor5/src/core';
 import LinkEditing from './linkediting';
-import LinkUI from './linkui';
-import AutoLink from './autolink';
+// import LinkUI from './linkui';
+// import AutoLink from './autolink';
 
 /**
  * The link plugin.
@@ -25,14 +25,14 @@ export default class Link extends Plugin {
 	 * @inheritDoc
 	 */
 	static get requires() {
-		return [ LinkEditing, LinkUI, AutoLink ];
+		return [ LinkEditing ];
 	}
 
 	/**
 	 * @inheritDoc
 	 */
 	static get pluginName() {
-		return 'Link';
+		return 'ResourceLink';
 	}
 }
 

--- a/packages/ckeditor5-link/src/linkcommand.js
+++ b/packages/ckeditor5-link/src/linkcommand.js
@@ -14,6 +14,8 @@ import { Collection, first, toMap } from 'ckeditor5/src/utils';
 import AutomaticDecorators from './utils/automaticdecorators';
 import { isLinkableElement } from './utils';
 
+import { RESOURCE_LINK } from './constants'
+
 /**
  * The link command. It is used by the {@link module:link/link~Link link feature}.
  *
@@ -72,11 +74,11 @@ export default class LinkCommand extends Command {
 		// A check for any integration that allows linking elements (e.g. `LinkImage`).
 		// Currently the selection reads attributes from text nodes only. See #7429 and #7465.
 		if ( isLinkableElement( selectedElement, model.schema ) ) {
-			this.value = selectedElement.getAttribute( 'linkHref' );
-			this.isEnabled = model.schema.checkAttribute( selectedElement, 'linkHref' );
+			this.value = selectedElement.getAttribute( RESOURCE_LINK );
+			this.isEnabled = model.schema.checkAttribute( selectedElement, RESOURCE_LINK );
 		} else {
-			this.value = selection.getAttribute( 'linkHref' );
-			this.isEnabled = model.schema.checkAttributeInSelection( selection, 'linkHref' );
+			this.value = selection.getAttribute( RESOURCE_LINK );
+			this.isEnabled = model.schema.checkAttributeInSelection( selection, RESOURCE_LINK );
 		}
 
 		for ( const manualDecorator of this.manualDecorators ) {
@@ -143,10 +145,10 @@ export default class LinkCommand extends Command {
 	 * decorator attributes.
 	 *
 	 * @fires execute
-	 * @param {String} href Link destination.
+	 * @param {String} uuid Link destination.
 	 * @param {Object} [manualDecoratorIds={}] The information about manual decorator attributes to be applied or removed upon execution.
 	 */
-	execute( href, manualDecoratorIds = {} ) {
+	execute( uuid, manualDecoratorIds = {} ) {
 		const model = this.editor.model;
 		const selection = model.document.selection;
 		// Stores information about manual decorators to turn them on/off when command is applied.
@@ -167,11 +169,11 @@ export default class LinkCommand extends Command {
 				const position = selection.getFirstPosition();
 
 				// When selection is inside text with `linkHref` attribute.
-				if ( selection.hasAttribute( 'linkHref' ) ) {
+				if ( selection.hasAttribute( RESOURCE_LINK ) ) {
 					// Then update `linkHref` value.
-					const linkRange = findAttributeRange( position, 'linkHref', selection.getAttribute( 'linkHref' ), model );
+					const linkRange = findAttributeRange( position, RESOURCE_LINK, selection.getAttribute( RESOURCE_LINK ), model );
 
-					writer.setAttribute( 'linkHref', href, linkRange );
+					writer.setAttribute( RESOURCE_LINK, uuid, linkRange );
 
 					truthyManualDecorators.forEach( item => {
 						writer.setAttribute( item, true, linkRange );
@@ -187,16 +189,16 @@ export default class LinkCommand extends Command {
 				// If not then insert text node with `linkHref` attribute in place of caret.
 				// However, since selection is collapsed, attribute value will be used as data for text node.
 				// So, if `href` is empty, do not create text node.
-				else if ( href !== '' ) {
+				else if ( uuid !== '' ) {
 					const attributes = toMap( selection.getAttributes() );
 
-					attributes.set( 'linkHref', href );
+					attributes.set( RESOURCE_LINK, uuid );
 
 					truthyManualDecorators.forEach( item => {
 						attributes.set( item, true );
 					} );
 
-					const { end: positionAfter } = model.insertContent( writer.createText( href, attributes ), position );
+					const { end: positionAfter } = model.insertContent( writer.createText( uuid, attributes ), position );
 
 					// Put the selection at the end of the inserted link.
 					// Using end of range returned from insertContent in case nodes with the same attributes got merged.
@@ -205,19 +207,19 @@ export default class LinkCommand extends Command {
 
 				// Remove the `linkHref` attribute and all link decorators from the selection.
 				// It stops adding a new content into the link element.
-				[ 'linkHref', ...truthyManualDecorators, ...falsyManualDecorators ].forEach( item => {
+				[ RESOURCE_LINK, ...truthyManualDecorators, ...falsyManualDecorators ].forEach( item => {
 					writer.removeSelectionAttribute( item );
 				} );
 			} else {
 				// If selection has non-collapsed ranges, we change attribute on nodes inside those ranges
 				// omitting nodes where the `linkHref` attribute is disallowed.
-				const ranges = model.schema.getValidRanges( selection.getRanges(), 'linkHref' );
+				const ranges = model.schema.getValidRanges( selection.getRanges(), RESOURCE_LINK );
 
 				// But for the first, check whether the `linkHref` attribute is allowed on selected blocks (e.g. the "image" element).
 				const allowedRanges = [];
 
 				for ( const element of selection.getSelectedBlocks() ) {
-					if ( model.schema.checkAttribute( element, 'linkHref' ) ) {
+					if ( model.schema.checkAttribute( element, RESOURCE_LINK ) ) {
 						allowedRanges.push( writer.createRangeOn( element ) );
 					}
 				}
@@ -234,7 +236,7 @@ export default class LinkCommand extends Command {
 				}
 
 				for ( const range of rangesToUpdate ) {
-					writer.setAttribute( 'linkHref', href, range );
+					writer.setAttribute( RESOURCE_LINK, uuid, range );
 
 					truthyManualDecorators.forEach( item => {
 						writer.setAttribute( item, true, range );

--- a/packages/ckeditor5-link/src/linkediting.js
+++ b/packages/ckeditor5-link/src/linkediting.js
@@ -25,6 +25,12 @@ const DECORATOR_AUTOMATIC = 'automatic';
 const DECORATOR_MANUAL = 'manual';
 const EXTERNAL_LINKS_REGEXP = /^(https?:)?\/\//;
 
+import {
+  RESOURCE_LINK,
+  RESOURCE_LINK_COMMAND,
+  RESOURCE_UNLINK_COMMAND 
+} from './constants'
+
 /**
  * The link engine feature.
  *
@@ -38,7 +44,7 @@ export default class LinkEditing extends Plugin {
 	 * @inheritDoc
 	 */
 	static get pluginName() {
-		return 'LinkEditing';
+		return 'ResourceLinkEditing';
 	}
 
 	/**
@@ -55,7 +61,7 @@ export default class LinkEditing extends Plugin {
 	constructor( editor ) {
 		super( editor );
 
-		editor.config.define( 'link', {
+		editor.config.define( 'resourceLink', {
 			addTargetToExternalLinks: false
 		} );
 	}
@@ -67,14 +73,14 @@ export default class LinkEditing extends Plugin {
 		const editor = this.editor;
 
 		// Allow link attribute on all inline nodes.
-		editor.model.schema.extend( '$text', { allowAttributes: 'linkHref' } );
+		editor.model.schema.extend( '$text', { allowAttributes: RESOURCE_LINK } );
 
 		editor.conversion.for( 'dataDowncast' )
-			.attributeToElement( { model: 'linkHref', view: createLinkElement } );
+			.attributeToElement( { model: RESOURCE_LINK, view: createLinkElement } );
 
 		editor.conversion.for( 'editingDowncast' )
-			.attributeToElement( { model: 'linkHref', view: ( href, conversionApi ) => {
-				return createLinkElement( ensureSafeUrl( href ), conversionApi );
+			.attributeToElement( { model: RESOURCE_LINK, view: ( uuid, conversionApi ) => {
+				return createLinkElement( uuid, conversionApi );
 			} } );
 
 		editor.conversion.for( 'upcast' )
@@ -82,18 +88,18 @@ export default class LinkEditing extends Plugin {
 				view: {
 					name: 'a',
 					attributes: {
-						href: true
+						'data-uuid': true
 					}
 				},
 				model: {
-					key: 'linkHref',
-					value: viewElement => viewElement.getAttribute( 'href' )
+					key: RESOURCE_LINK,
+					value: viewElement => viewElement.getAttribute( 'data-uuid' )
 				}
 			} );
 
 		// Create linking commands.
-		editor.commands.add( 'link', new LinkCommand( editor ) );
-		editor.commands.add( 'unlink', new UnlinkCommand( editor ) );
+		editor.commands.add( RESOURCE_LINK_COMMAND, new LinkCommand( editor ) );
+		editor.commands.add( RESOURCE_UNLINK_COMMAND, new UnlinkCommand( editor ) );
 
 		const linkDecorators = getLocalizedDecorators( editor.t, normalizeDecorators( editor.config.get( 'link.decorators' ) ) );
 
@@ -102,10 +108,10 @@ export default class LinkEditing extends Plugin {
 
 		// Enable two-step caret movement for `linkHref` attribute.
 		const twoStepCaretMovementPlugin = editor.plugins.get( TwoStepCaretMovement );
-		twoStepCaretMovementPlugin.registerAttribute( 'linkHref' );
+		twoStepCaretMovementPlugin.registerAttribute( RESOURCE_LINK );
 
 		// Setup highlight over selected link.
-		inlineHighlight( editor, 'linkHref', 'a', HIGHLIGHT_CLASS );
+		inlineHighlight( editor, RESOURCE_LINK, 'a', HIGHLIGHT_CLASS );
 
 		// Change the attributes of the selection in certain situations after the link was inserted into the document.
 		this._enableInsertContentSelectionAttributesFixer();
@@ -136,7 +142,7 @@ export default class LinkEditing extends Plugin {
 		const editor = this.editor;
 		// Store automatic decorators in the command instance as we do the same with manual decorators.
 		// Thanks to that, `LinkImageEditing` plugin can re-use the same definitions.
-		const command = editor.commands.get( 'link' );
+		const command = editor.commands.get( RESOURCE_LINK_COMMAND );
 		const automaticDecorators = command.automaticDecorators;
 
 		// Adds a default decorator for external links.
@@ -177,7 +183,7 @@ export default class LinkEditing extends Plugin {
 		}
 
 		const editor = this.editor;
-		const command = editor.commands.get( 'link' );
+		const command = editor.commands.get( RESOURCE_LINK_COMMAND );
 		const manualDecorators = command.manualDecorators;
 
 		manualDecoratorDefinitions.forEach( decorator => {
@@ -249,7 +255,7 @@ export default class LinkEditing extends Plugin {
 			//
 			// If the selection is not "trapped" by the `linkHref` attribute after inserting, there's nothing
 			// to fix there.
-			if ( !selection.hasAttribute( 'linkHref' ) ) {
+			if ( !selection.hasAttribute( RESOURCE_LINK ) ) {
 				return;
 			}
 
@@ -281,7 +287,7 @@ export default class LinkEditing extends Plugin {
 			//		                                                          ↱
 			//		<$text bold="true">INSERTED</$text><$text linkHref="foo">[]link</$text>
 			//
-			if ( !nodeBefore.hasAttribute( 'linkHref' ) ) {
+			if ( !nodeBefore.hasAttribute( RESOURCE_LINK ) ) {
 				return;
 			}
 
@@ -299,7 +305,7 @@ export default class LinkEditing extends Plugin {
 			//		                                                             ↰
 			//		<$text linkHref="foo">l</$text><$text linkHref="bar">INSERTED[]</$text><$text linkHref="foo">ink</$text>
 			//
-			if ( nodeAfter && nodeAfter.hasAttribute( 'linkHref' ) ) {
+			if ( nodeAfter && nodeAfter.hasAttribute( RESOURCE_LINK ) ) {
 				return;
 			}
 
@@ -350,12 +356,12 @@ export default class LinkEditing extends Plugin {
 			}
 
 			// ...and clicked text is the link...
-			if ( !selection.hasAttribute( 'linkHref' ) ) {
+			if ( !selection.hasAttribute( RESOURCE_LINK ) ) {
 				return;
 			}
 
 			const position = selection.getFirstPosition();
-			const linkRange = findAttributeRange( position, 'linkHref', selection.getAttribute( 'linkHref' ), model );
+			const linkRange = findAttributeRange( position, RESOURCE_LINK, selection.getAttribute( RESOURCE_LINK ), model );
 
 			// ...check whether clicked start/end boundary of the link.
 			// If so, remove the `linkHref` attribute.
@@ -481,13 +487,13 @@ export default class LinkEditing extends Plugin {
 			shouldPreserveAttributes = false;
 
 			const position = selection.getFirstPosition();
-			const linkHref = selection.getAttribute( 'linkHref' );
+			const linkHref = selection.getAttribute( RESOURCE_LINK );
 
 			if ( !linkHref ) {
 				return;
 			}
 
-			const linkRange = findAttributeRange( position, 'linkHref', linkHref, model );
+			const linkRange = findAttributeRange( position, RESOURCE_LINK, linkHref, model );
 
 			// Preserve `linkHref` attribute if the selection is in the middle of the link or
 			// the selection is at the end of the link and 2-SCM is activated.
@@ -523,7 +529,7 @@ export default class LinkEditing extends Plugin {
 // @param {module:engine/model/writer~Writer} writer
 // @param {Array.<String>} linkAttributes
 function removeLinkAttributesFromSelection( writer, linkAttributes ) {
-	writer.removeSelectionAttribute( 'linkHref' );
+	writer.removeSelectionAttribute( RESOURCE_LINK );
 
 	for ( const attribute of linkAttributes ) {
 		writer.removeSelectionAttribute( attribute );
@@ -551,7 +557,7 @@ function shouldCopyAttributes( model ) {
 	}
 
 	// ...or isn't the link.
-	if ( !nodeAtFirstPosition.hasAttribute( 'linkHref' ) ) {
+	if ( !nodeAtFirstPosition.hasAttribute( RESOURCE_LINK ) ) {
 		return false;
 	}
 
@@ -566,7 +572,7 @@ function shouldCopyAttributes( model ) {
 
 	// If nodes are not equal, maybe the link nodes has defined additional attributes inside.
 	// First, we need to find the entire link range.
-	const linkRange = findAttributeRange( firstPosition, 'linkHref', nodeAtFirstPosition.getAttribute( 'linkHref' ), model );
+	const linkRange = findAttributeRange( firstPosition, RESOURCE_LINK, nodeAtFirstPosition.getAttribute( RESOURCE_LINK ), model );
 
 	// Then we can check whether selected range is inside the found link range. If so, attributes should be preserved.
 	return linkRange.containsRange( model.createRange( firstPosition, lastPosition ), true );
@@ -589,5 +595,5 @@ function isTyping( editor ) {
 function getLinkAttributesAllowedOnText( schema ) {
 	const textAttributes = schema.getDefinition( '$text' ).allowAttributes;
 
-	return textAttributes.filter( attribute => attribute.startsWith( 'link' ) );
+	return textAttributes.filter( attribute => attribute.startsWith( 'resource' ) );
 }

--- a/packages/ckeditor5-link/src/linkimage.js
+++ b/packages/ckeditor5-link/src/linkimage.js
@@ -33,6 +33,6 @@ export default class LinkImage extends Plugin {
 	 * @inheritDoc
 	 */
 	static get pluginName() {
-		return 'LinkImage';
+		return 'ResourceLinkImage';
 	}
 }

--- a/packages/ckeditor5-link/src/linkimageediting.js
+++ b/packages/ckeditor5-link/src/linkimageediting.js
@@ -33,7 +33,7 @@ export default class LinkImageEditing extends Plugin {
 	 * @inheritDoc
 	 */
 	static get pluginName() {
-		return 'LinkImageEditing';
+		return 'ResourceLinkImageEditing';
 	}
 
 	init() {

--- a/packages/ckeditor5-link/src/linkimageui.js
+++ b/packages/ckeditor5-link/src/linkimageui.js
@@ -17,6 +17,8 @@ import { LINK_KEYSTROKE } from './utils';
 
 import linkIcon from '../theme/icons/link.svg';
 
+import { RESOURCE_LINK_UI } from './constants'
+
 /**
  * The link image UI plugin.
  *
@@ -37,7 +39,7 @@ export default class LinkImageUI extends Plugin {
 	 * @inheritDoc
 	 */
 	static get pluginName() {
-		return 'LinkImageUI';
+		return 'ResourceLinkImageUI';
 	}
 
 	/**
@@ -74,9 +76,9 @@ export default class LinkImageUI extends Plugin {
 		const editor = this.editor;
 		const t = editor.t;
 
-		editor.ui.componentFactory.add( 'linkImage', locale => {
+		editor.ui.componentFactory.add( 'linkResourceImage', locale => {
 			const button = new ButtonView( locale );
-			const plugin = editor.plugins.get( 'LinkUI' );
+			const plugin = editor.plugins.get( RESOURCE_LINK_UI );
 			const linkCommand = editor.commands.get( 'link' );
 
 			button.set( {

--- a/packages/ckeditor5-link/src/linkui.js
+++ b/packages/ckeditor5-link/src/linkui.js
@@ -19,6 +19,14 @@ import linkIcon from '../theme/icons/link.svg';
 
 const VISUAL_SELECTION_MARKER_NAME = 'link-ui';
 
+import {
+  RESOURCE_LINK,
+  RESOURCE_LINK_UI,
+  RESOURCE_LINK_COMMAND,
+  RESOURCE_UNLINK_COMMAND 
+} from './constants'
+
+
 /**
  * The link UI plugin. It introduces the `'link'` and `'unlink'` buttons and support for the <kbd>Ctrl+K</kbd> keystroke.
  *
@@ -39,7 +47,7 @@ export default class LinkUI extends Plugin {
 	 * @inheritDoc
 	 */
 	static get pluginName() {
-		return 'LinkUI';
+		return RESOURCE_LINK_UI;
 	}
 
 	/**
@@ -115,10 +123,10 @@ export default class LinkUI extends Plugin {
 	_createActionsView() {
 		const editor = this.editor;
 		const actionsView = new LinkActionsView( editor.locale );
-		const linkCommand = editor.commands.get( 'link' );
-		const unlinkCommand = editor.commands.get( 'unlink' );
+		const linkCommand = editor.commands.get( RESOURCE_LINK_COMMAND );
+		const unlinkCommand = editor.commands.get( RESOURCE_UNLINK_COMMAND );
 
-		actionsView.bind( 'href' ).to( linkCommand, 'value' );
+		actionsView.bind( 'data-uuid' ).to( linkCommand, 'value' );
 		actionsView.editButtonView.bind( 'isEnabled' ).to( linkCommand );
 		actionsView.unlinkButtonView.bind( 'isEnabled' ).to( unlinkCommand );
 
@@ -128,8 +136,8 @@ export default class LinkUI extends Plugin {
 		} );
 
 		// Execute unlink command after clicking on the "Unlink" button.
-		this.listenTo( actionsView, 'unlink', () => {
-			editor.execute( 'unlink' );
+		this.listenTo( actionsView, RESOURCE_UNLINK_COMMAND, () => {
+			editor.execute( RESOURCE_UNLINK_COMMAND );
 			this._hideUI();
 		} );
 
@@ -156,7 +164,7 @@ export default class LinkUI extends Plugin {
 	 */
 	_createFormView() {
 		const editor = this.editor;
-		const linkCommand = editor.commands.get( 'link' );
+		const linkCommand = editor.commands.get( RESOURCE_LINK_COMMAND );
 		const defaultProtocol = editor.config.get( 'link.defaultProtocol' );
 
 		const formView = new LinkFormView( editor.locale, linkCommand );
@@ -171,7 +179,7 @@ export default class LinkUI extends Plugin {
 		this.listenTo( formView, 'submit', () => {
 			const { value } = formView.urlInputView.fieldView.element;
 			const parsedUrl = addLinkProtocolIfApplicable( value, defaultProtocol );
-			editor.execute( 'link', parsedUrl, formView.getDecoratorSwitchesState() );
+			editor.execute(RESOURCE_LINK_COMMAND, parsedUrl, formView.getDecoratorSwitchesState() );
 			this._closeFormView();
 		} );
 
@@ -197,7 +205,7 @@ export default class LinkUI extends Plugin {
 	 */
 	_createToolbarLinkButton() {
 		const editor = this.editor;
-		const linkCommand = editor.commands.get( 'link' );
+		const linkCommand = editor.commands.get( RESOURCE_LINK_COMMAND );
 		const t = editor.t;
 
 		// Handle the `Ctrl+K` keystroke and show the panel.
@@ -214,9 +222,10 @@ export default class LinkUI extends Plugin {
 			const button = new ButtonView( locale );
 
 			button.isEnabled = true;
-			button.label = t( 'Link' );
+			button.label = t( 'Resource Link' );
 			button.icon = linkIcon;
-			button.keystroke = LINK_KEYSTROKE;
+                  button.text = 'Link Resource';
+                  button.keystroke = LINK_KEYSTROKE;
 			button.tooltip = true;
 			button.isToggleable = true;
 
@@ -308,7 +317,7 @@ export default class LinkUI extends Plugin {
 		}
 
 		const editor = this.editor;
-		const linkCommand = editor.commands.get( 'link' );
+		const linkCommand = editor.commands.get( RESOURCE_LINK );
 
 		this.formView.disableCssTransitions();
 
@@ -343,7 +352,7 @@ export default class LinkUI extends Plugin {
 	 * @private
 	 */
 	_closeFormView() {
-		const linkCommand = this.editor.commands.get( 'link' );
+		const linkCommand = this.editor.commands.get( RESOURCE_LINK );
 
 		// Restore manual decorator states to represent the current model state. This case is important to reset the switch buttons
 		// when the user cancels the editing form.

--- a/packages/ckeditor5-link/src/utils.js
+++ b/packages/ckeditor5-link/src/utils.js
@@ -8,6 +8,7 @@
  */
 
 import { upperFirst } from 'lodash-es';
+import { RESOURCE_LINK_CKEDITOR_CLASS } from './constants'
 
 const ATTRIBUTE_WHITESPACES = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205f\u3000]/g; // eslint-disable-line no-control-regex
 const SAFE_URL = /^(?:(?:https?|ftps?|mailto):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i;
@@ -41,9 +42,9 @@ export function isLinkElement( node ) {
  * @param {module:engine/conversion/downcastdispatcher~DowncastConversionApi} conversionApi
  * @returns {module:engine/view/attributeelement~AttributeElement}
  */
-export function createLinkElement( href, { writer } ) {
+export function createLinkElement( uuid, { writer } ) {
 	// Priority 5 - https://github.com/ckeditor/ckeditor5-link/issues/121.
-	const linkElement = writer.createAttributeElement( 'a', { href }, { priority: 5 } );
+  const linkElement = writer.createAttributeElement( 'a', { 'data-uuid': uuid, class: RESOURCE_LINK_CKEDITOR_CLASS }, { priority: 5 } );
 	writer.setCustomProperty( 'link', true, linkElement );
 
 	return linkElement;

--- a/packages/ckeditor5-link/tests/linkimageui.js
+++ b/packages/ckeditor5-link/tests/linkimageui.js
@@ -92,7 +92,7 @@ describe( 'LinkImageUI', () => {
 			} );
 
 			it( 'should call #_showUI upon #execute', () => {
-				const spy = testUtils.sinon.stub( editor.plugins.get( 'LinkUI' ), '_showUI' );
+				const spy = testUtils.sinon.stub( editor.plugins.get( RESOURCE_LINK_UI ), '_showUI' );
 
 				linkButton.fire( 'execute' );
 				sinon.assert.calledWithExactly( spy, true );
@@ -142,7 +142,7 @@ describe( 'LinkImageUI', () => {
 			let linkUI;
 
 			beforeEach( () => {
-				linkUI = editor.plugins.get( 'LinkUI' );
+				linkUI = editor.plugins.get( RESOURCE_LINK_UI );
 			} );
 
 			it( 'should not show the LinkUI when clicked the linked image', () => {
@@ -196,7 +196,7 @@ describe( 'LinkImageUI', () => {
 
 		describe( 'when a block image is selected', () => {
 			it( 'should show plugin#actionsView after "execute" if an image is already linked', () => {
-				const linkUIPlugin = editor.plugins.get( 'LinkUI' );
+				const linkUIPlugin = editor.plugins.get( RESOURCE_LINK_UI );
 
 				editor.setData( '<figure class="image"><a href="https://example.com"><img src="" /></a></figure>' );
 
@@ -210,7 +210,7 @@ describe( 'LinkImageUI', () => {
 			} );
 
 			it( 'should show plugin#formView after "execute" if image is not linked', () => {
-				const linkUIPlugin = editor.plugins.get( 'LinkUI' );
+				const linkUIPlugin = editor.plugins.get( RESOURCE_LINK_UI );
 
 				editor.setData( '<figure class="image"><img src="" /></a>' );
 
@@ -226,7 +226,7 @@ describe( 'LinkImageUI', () => {
 
 		describe( 'when an inline image is selected', () => {
 			it( 'should show plugin#actionsView after "execute" if an image is already linked', () => {
-				const linkUIPlugin = editor.plugins.get( 'LinkUI' );
+				const linkUIPlugin = editor.plugins.get( RESOURCE_LINK_UI );
 
 				editor.setData( '<p><a href="https://example.com"><img src="/assets/sample.png" /></a></p>' );
 
@@ -240,7 +240,7 @@ describe( 'LinkImageUI', () => {
 			} );
 
 			it( 'should show plugin#formView after "execute" if image is not linked', () => {
-				const linkUIPlugin = editor.plugins.get( 'LinkUI' );
+				const linkUIPlugin = editor.plugins.get( RESOURCE_LINK_UI );
 
 				editor.setData( '<p><img src="" /></p>' );
 

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -27,7 +27,7 @@ import LinkUI from '../src/linkui';
 import LinkFormView from '../src/ui/linkformview';
 import LinkActionsView from '../src/ui/linkactionsview';
 
-describe( 'LinkUI', () => {
+describe( RESOURCE_LINK_UI, () => {
 	let editor, linkUIFeature, linkButton, balloon, formView, actionsView, editorElement;
 
 	testUtils.createSinonSandbox();
@@ -64,7 +64,7 @@ describe( 'LinkUI', () => {
 	} );
 
 	it( 'should be named', () => {
-		expect( LinkUI.pluginName ).to.equal( 'LinkUI' );
+		expect( LinkUI.pluginName ).to.equal( RESOURCE_LINK_UI );
 	} );
 
 	it( 'should load ContextualBalloon', () => {


### PR DESCRIPTION
this has the changes I've been making to the CKEditor `Link` plugin code in order for us to use it as the base for a better user experience for linking to resources in our markdown editor in [ocw-studio](https://github.com/mitodl/ocw-studio).

The changes are basically, right now, limited to renaming constants used to identify the model type, command names, and so on so that they do not collide with the existing, normal link plugin. The hope is that if we keep this changeset small, once we've merged this PR into our forked repo we'll be able to keep this repo up-to-date with upstream in order to ensure that this resource link plugin will continue to work with the rest of the ckeditor ecosystem.